### PR TITLE
feat: set up pnpm workspace with shared libs and React app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.DS_Store
+dist
+*.log
+.vscode
+.idea
+.next
+coverage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# YD AI Monorepo
+
+This repository is a pnpm workspace that hosts a couple of reusable packages and a React playground for manual testing.
+
+## Packages
+
+- `@yd/libs` – shared TypeScript utilities. Currently includes helpers such as `formatWalletAddress` for shortening MetaMask style addresses.
+- `@yd/hooks` – React hooks composed with Immer state helpers. The `useWallet` hook wraps simple MetaMask style connect/disconnect flows while using the utilities from `@yd/libs`.
+
+## Apps
+
+- `yd-app` – a Vite based React/TypeScript application that demonstrates how to consume the shared library and hooks packages.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm -r build
+pnpm --filter yd-app dev
+```
+
+The React playground listens on port `5173` by default.

--- a/apps/yd-app/index.html
+++ b/apps/yd-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>YD Monorepo Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/yd-app/package.json
+++ b/apps/yd-app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "yd-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 5173",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "@yd/hooks": "workspace:^0.0.1",
+    "@yd/libs": "workspace:^0.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.42",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/apps/yd-app/src/App.tsx
+++ b/apps/yd-app/src/App.tsx
@@ -1,0 +1,78 @@
+import { useMemo, useState } from 'react';
+import { formatWalletAddress } from '@yd/libs';
+import { useWallet } from '@yd/hooks';
+
+const SAMPLE_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+
+function StateRow({ label, value }: { label: string; value: string | undefined }) {
+  return (
+    <div className="state-row">
+      <span className="state-label">{label}</span>
+      <span className="state-value">{value ?? '—'}</span>
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return <h2 className="section-title">{children}</h2>;
+}
+
+const App = () => {
+  const [addressInput, setAddressInput] = useState<string>(SAMPLE_ADDRESS);
+  const manualFormattedAddress = useMemo(() => formatWalletAddress(addressInput), [addressInput]);
+
+  const { state, formattedAddress, connect, disconnect, setAddress } = useWallet();
+
+  return (
+    <div className="app-container">
+      <header>
+        <h1>YD Monorepo Playground</h1>
+        <p>Utilities and hooks for Ethereum wallets, built with pnpm workspaces.</p>
+      </header>
+
+      <section className="card">
+        <SectionTitle>Format wallet address</SectionTitle>
+        <p>Use the shared utility from <code>@yd/libs</code> to keep addresses readable.</p>
+        <label className="input-label" htmlFor="address-input">
+          Wallet Address
+        </label>
+        <input
+          id="address-input"
+          value={addressInput}
+          onChange={(event) => setAddressInput(event.target.value)}
+          placeholder="0x..."
+        />
+        <div className="highlight">Formatted: {manualFormattedAddress}</div>
+      </section>
+
+      <section className="card">
+        <SectionTitle>useWallet hook demo</SectionTitle>
+        <p>
+          The hook combines <code>useImmer</code> with the formatting helper. Try connecting to MetaMask or simulate a
+          connection using the input above.
+        </p>
+        <div className="button-row">
+          <button type="button" onClick={() => void connect()} className="primary">
+            Connect MetaMask
+          </button>
+          <button type="button" onClick={disconnect}>
+            Disconnect
+          </button>
+          <button type="button" onClick={() => setAddress(addressInput)}>
+            Simulate Address
+          </button>
+        </div>
+        <div className="state-panel">
+          <StateRow label="Status" value={state.status} />
+          <StateRow label="Connected" value={state.isConnected ? 'Yes' : 'No'} />
+          <StateRow label="Chain ID" value={state.chainId} />
+          <StateRow label="Raw Address" value={state.address} />
+          <StateRow label="Formatted" value={formattedAddress} />
+          <StateRow label="Error" value={state.error} />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default App;

--- a/apps/yd-app/src/index.css
+++ b/apps/yd-app/src/index.css
@@ -1,0 +1,141 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f1f5f9;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.app-container {
+  width: min(960px, 100%);
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+header {
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+section.card {
+  background: white;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 12px 32px -20px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-title {
+  margin: 0;
+}
+
+.input-label {
+  font-weight: 600;
+}
+
+input {
+  width: 100%;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+}
+
+.highlight {
+  background: #eff6ff;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.65rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid #1e3a8a;
+  background: white;
+  color: #1e3a8a;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: white;
+  border: none;
+  box-shadow: 0 10px 20px -10px rgba(37, 99, 235, 0.75);
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -12px rgba(15, 23, 42, 0.25);
+}
+
+.state-panel {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.state-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.9rem;
+}
+
+.state-label {
+  font-weight: 600;
+  color: #475569;
+}
+
+.state-value {
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  color: #0f172a;
+}
+
+@media (max-width: 600px) {
+  section.card {
+    padding: 1.25rem;
+  }
+
+  .button-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/apps/yd-app/src/main.tsx
+++ b/apps/yd-app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/yd-app/tsconfig.json
+++ b/apps/yd-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/yd-app/tsconfig.node.json
+++ b/apps/yd-app/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/yd-app/vite.config.ts
+++ b/apps/yd-app/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src')
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "yd-ai-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.12.4",
+  "scripts": {
+    "build": "pnpm -r --workspace-concurrency=1 build",
+    "dev": "pnpm --filter yd-app dev"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^11.1.5",
+    "rollup": "^3.29.4",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/yd-hooks/package.json
+++ b/packages/yd-hooks/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@yd/hooks",
+  "version": "0.0.1",
+  "description": "Reusable hooks for wallet interactions built with Immer",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "dependencies": {
+    "@yd/libs": "workspace:^0.0.1",
+    "use-immer": "^0.9.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.2.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/packages/yd-hooks/rollup.config.mjs
+++ b/packages/yd-hooks/rollup.config.mjs
@@ -1,0 +1,31 @@
+import typescript from '@rollup/plugin-typescript';
+import pkg from './package.json' assert { type: 'json' };
+
+const external = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {})
+];
+
+export default {
+  input: 'src/index.ts',
+  external,
+  output: [
+    {
+      file: pkg.module,
+      format: 'esm',
+      sourcemap: true
+    },
+    {
+      file: pkg.main,
+      format: 'cjs',
+      sourcemap: true
+    }
+  ],
+  plugins: [
+    typescript({
+      tsconfig: './tsconfig.json',
+      declaration: true,
+      declarationDir: 'dist'
+    })
+  ]
+};

--- a/packages/yd-hooks/src/index.ts
+++ b/packages/yd-hooks/src/index.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useImmer } from 'use-immer';
+import { formatWalletAddress } from '@yd/libs';
+
+export interface WalletState {
+  address?: string;
+  chainId?: string;
+  isConnected: boolean;
+  status: 'idle' | 'connecting' | 'error';
+  error?: string;
+}
+
+export interface UseWalletOptions {
+  /**
+   * Automatically attempt to connect to an injected provider when the hook mounts.
+   */
+  autoConnect?: boolean;
+}
+
+interface EthereumProvider {
+  request<T = unknown>(args: { method: string; params?: unknown[] }): Promise<T>;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  removeListener?(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+const defaultState: WalletState = {
+  address: undefined,
+  chainId: undefined,
+  isConnected: false,
+  status: 'idle',
+  error: undefined
+};
+
+function getEthereumProvider(): EthereumProvider | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return (window as unknown as { ethereum?: EthereumProvider }).ethereum;
+}
+
+async function requestAccounts(provider: EthereumProvider): Promise<string[]> {
+  const accounts = await provider.request<string[]>({ method: 'eth_requestAccounts' });
+  if (!Array.isArray(accounts)) {
+    return [];
+  }
+
+  return accounts;
+}
+
+async function requestChainId(provider: EthereumProvider): Promise<string | undefined> {
+  const chainId = await provider.request<string>({ method: 'eth_chainId' });
+  return typeof chainId === 'string' ? chainId : undefined;
+}
+
+export function useWallet(options: UseWalletOptions = {}) {
+  const { autoConnect = false } = options;
+  const [state, update] = useImmer<WalletState>(defaultState);
+
+  const connect = useCallback(async () => {
+    const provider = getEthereumProvider();
+    if (!provider || typeof provider.request !== 'function') {
+      update((draft) => {
+        draft.status = 'error';
+        draft.error = 'MetaMask (window.ethereum) was not found.';
+        draft.isConnected = false;
+      });
+      return;
+    }
+
+    update((draft) => {
+      draft.status = 'connecting';
+      draft.error = undefined;
+    });
+
+    try {
+      const accounts = await requestAccounts(provider);
+      const chainId = await requestChainId(provider);
+      const [primary] = accounts ?? [];
+
+      update((draft) => {
+        draft.address = primary;
+        draft.chainId = chainId;
+        draft.isConnected = Boolean(primary);
+        draft.status = 'idle';
+        draft.error = undefined;
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      update((draft) => {
+        draft.status = 'error';
+        draft.error = message;
+        draft.isConnected = false;
+      });
+    }
+  }, [update]);
+
+  const disconnect = useCallback(() => {
+    update((draft) => {
+      draft.address = undefined;
+      draft.chainId = undefined;
+      draft.isConnected = false;
+      draft.status = 'idle';
+      draft.error = undefined;
+    });
+  }, [update]);
+
+  const setAddress = useCallback(
+    (address?: string) => {
+      update((draft) => {
+        draft.address = address;
+        draft.isConnected = Boolean(address);
+        draft.status = 'idle';
+      });
+    },
+    [update]
+  );
+
+  const formattedAddress = useMemo(() => formatWalletAddress(state.address), [state.address]);
+
+  useEffect(() => {
+    if (!autoConnect) {
+      return;
+    }
+
+    void connect();
+  }, [autoConnect, connect]);
+
+  useEffect(() => {
+    const provider = getEthereumProvider();
+    if (!provider?.on || !provider?.removeListener) {
+      return;
+    }
+
+    const handleAccountsChanged = (accounts: unknown) => {
+      const [address] = Array.isArray(accounts) ? (accounts as string[]) : [];
+      setAddress(address);
+    };
+
+    const handleChainChanged = (chainId: unknown) => {
+      update((draft) => {
+        draft.chainId = typeof chainId === 'string' ? chainId : undefined;
+      });
+    };
+
+    provider.on('accountsChanged', handleAccountsChanged);
+    provider.on('chainChanged', handleChainChanged);
+
+    return () => {
+      provider.removeListener?.('accountsChanged', handleAccountsChanged);
+      provider.removeListener?.('chainChanged', handleChainChanged);
+    };
+  }, [setAddress, update]);
+
+  return {
+    state,
+    formattedAddress,
+    connect,
+    disconnect,
+    setAddress
+  };
+}

--- a/packages/yd-hooks/tsconfig.json
+++ b/packages/yd-hooks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/yd-libs/package.json
+++ b/packages/yd-libs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@yd/libs",
+  "version": "0.0.1",
+  "description": "Utility functions for YD applications",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/packages/yd-libs/rollup.config.mjs
+++ b/packages/yd-libs/rollup.config.mjs
@@ -1,0 +1,31 @@
+import typescript from '@rollup/plugin-typescript';
+import pkg from './package.json' assert { type: 'json' };
+
+const external = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {})
+];
+
+export default {
+  input: 'src/index.ts',
+  external,
+  output: [
+    {
+      file: pkg.module,
+      format: 'esm',
+      sourcemap: true
+    },
+    {
+      file: pkg.main,
+      format: 'cjs',
+      sourcemap: true
+    }
+  ],
+  plugins: [
+    typescript({
+      tsconfig: './tsconfig.json',
+      declaration: true,
+      declarationDir: 'dist'
+    })
+  ]
+};

--- a/packages/yd-libs/src/index.ts
+++ b/packages/yd-libs/src/index.ts
@@ -1,0 +1,52 @@
+export interface FormatWalletAddressOptions {
+  /**
+   * Number of characters to keep at the start of the address.
+   * Defaults to 6, which includes the `0x` prefix and four characters after it.
+   */
+  prefixLength?: number;
+  /**
+   * Number of characters to keep at the end of the address.
+   * Defaults to 4.
+   */
+  suffixLength?: number;
+  /**
+   * Placeholder used when the address is missing or invalid.
+   */
+  placeholder?: string;
+}
+
+const DEFAULT_PREFIX_LENGTH = 6;
+const DEFAULT_SUFFIX_LENGTH = 4;
+const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{4,}$/;
+
+/**
+ * Format a wallet address for display by keeping characters at the beginning and end.
+ *
+ * @example
+ * ```ts
+ * formatWalletAddress('0x1234567890abcdef'); // → "0x1234...cdef"
+ * ```
+ */
+export function formatWalletAddress(
+  address: string | undefined | null,
+  options: FormatWalletAddressOptions = {}
+): string {
+  const { prefixLength = DEFAULT_PREFIX_LENGTH, suffixLength = DEFAULT_SUFFIX_LENGTH, placeholder = 'N/A' } = options;
+
+  if (!address || typeof address !== 'string') {
+    return placeholder;
+  }
+
+  const trimmed = address.trim();
+  if (!ADDRESS_PATTERN.test(trimmed) || trimmed.length <= prefixLength + suffixLength) {
+    return trimmed || placeholder;
+  }
+
+  const prefix = trimmed.slice(0, prefixLength);
+  const suffix = trimmed.slice(-suffixLength);
+  return `${prefix}...${suffix}`;
+}
+
+export const walletUtils = {
+  formatWalletAddress
+};

--- a/packages/yd-libs/tsconfig.json
+++ b/packages/yd-libs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - packages/*
+  - apps/*

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- configure a pnpm-based monorepo with shared TypeScript configuration
- add @yd/libs with wallet formatting helpers and rollup build setup
- add @yd/hooks with a MetaMask-oriented useWallet hook powered by use-immer
- scaffold a Vite React playground to exercise the utilities and hooks

## Testing
- pnpm install *(fails: blocked by proxy when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d39f7f3f18832e9c2e470017ffbd7a